### PR TITLE
feat: add a Dockerfile for reproducible builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 /public/ext.json
+
+# editor
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:16-alpine as build
+
+WORKDIR /app
+COPY package*.json ./
+COPY yarn.lock ./
+RUN yarn install
+COPY . .
+
+EXPOSE 8001
+CMD ["yarn", "start"]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,15 @@ The general instructions setting up an environment to develop Standard Notes ext
 
 ### Testing in the browser
 
+#### Local
+
 1. To run the app in development mode, run `yarn start` and visit http://localhost:8001. Press `ctrl/cmd + C` to exit development mode.
+
+#### Docker
+
+1. To run the app in a docker container simply run `docker compose up`.
+
+To build the app run `docker compose exec editor yarn run build`.
 
 ### Testing in the Standard Notes app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+
+services:
+  editor:
+    build:
+      context: .
+    ports:
+      - "8001:8001"
+    environment:
+      HOST: 0.0.0.0
+    volumes:
+      - ./:/app
+      - node_modules:/app/node_modules
+
+volumes:
+  node_modules:


### PR DESCRIPTION
The template does not work on my local environment with node:19. I also don't want to change my local node version, that's why I need a Dockerfile to run the project.